### PR TITLE
Allowed country is configurable

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -229,7 +229,7 @@ function commandHandler(db) {
                 fetch(`https://new.scoresaber.com/api/player/${args[0]}/full`)
                     .then(res => res.json())
                     .then(res => {
-                        if (res.playerInfo.country === "FI") {
+                        if (res.playerInfo.country === config.country) {
                             message.channel.send("Trying to add you...");
                             db.collection("discordRankBotUsers").find(query).toArray(function (err, dbres) {
                                 if (err) throw err;

--- a/exampleconfig.json
+++ b/exampleconfig.json
@@ -2,5 +2,6 @@
     "prefix" : "",
     "token" : "",
     "updateIntervalHours": ,
-    "guildId" : ""
+    "guildId" : "",
+    "country": ""
 }


### PR DESCRIPTION
Rather than having a hardcoded "FI"-check in the code, it should be configurable for greater usability. Requires adding a "country"-configuration to any existing bots.